### PR TITLE
Remove `date_default_timezone_set()` from FailureContext

### DIFF
--- a/src/Context/FailureContext.php
+++ b/src/Context/FailureContext.php
@@ -120,8 +120,6 @@ class FailureContext implements MinkAwareContext, FailStateInterface, DebugBarIn
      */
     public function __construct(array $output = [])
     {
-        date_default_timezone_set('Europe/London');
-
         $this->outputOptions = $output;
         self::$self = $this;
     }


### PR DESCRIPTION
Enabling the FailureContext leads to the default timezone being changed from what was configured previously, thus breaking some of my tests that rely on a particular timezone.

I don't see why changing the timezone is necessary in the first place?

The relevant line seems to be present right from the start, so maybe it was a leftover from early development days? My assumption is that changing such a basic PHP setting in a hard-coded way cannot really be right or intended.


