### PR TITLE
Remove window name argument; current drivers ignore or fail with current

### DIFF
--- a/src/Service/Screenshot.php
+++ b/src/Service/Screenshot.php
@@ -186,7 +186,7 @@ class Screenshot implements ScreenshotInterface
             return;
         }
 
-        $driver->resizeWindow((int) $size[0], (int) $size[1], 'current');
+        $driver->resizeWindow((int) $size[0], (int) $size[1]);
     }
 
     /**


### PR DESCRIPTION
When taking a screenshot, either directly or on failure, passing "current" as the window name argument is currently ignored by both php-webdriver and the dmore mink chrome driver (so has no effect), and causes a failure when used with the oleg-andreyev mink phpwebdriver extension (which checks to see if the window name is passed as a value other than null).

As neither php-webdriver (always using the "current" window handle) or the dmore mink chrome driver (uses it's own JS based method of resizing that doesn't use this value), removing this argument should have no detrimental effect on most (all) use cases.  