### PR TITLE
Symfomy 8.x interface compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,13 +9,13 @@
     }
   ],
   "require": {
+    "behat/behat": "^3.5",
     "behat/mink": "*@stable",
     "behat/mink-extension": "~2.0",
     "behat/mink-selenium2-driver": "~1.3"
   },
   "require-dev": {
     "phpunit/phpunit": "~4.0",
-    "behat/behat": "^3.5",
     "behat/mink-goutte-driver": "^1.2",
     "ciaranmcnulty/behat-localwebserverextension": "^1.1"
   },

--- a/src/Context/FailureContext.php
+++ b/src/Context/FailureContext.php
@@ -542,19 +542,15 @@ class FailureContext implements MinkAwareContext, FailStateInterface, DebugBarIn
     }
 
 
-    public function setMink(Mink $mink)
+    public function setMink(Mink $mink): void
     {
         $this->mink = $mink;
-
-        return $this;
     }
 
 
-    public function setMinkParameters(array $parameters)
+    public function setMinkParameters(array $parameters): void
     {
         $this->minkParameters = $parameters;
-
-        return $this;
     }
 
     /**

--- a/src/Extension/ServiceContainer/Extension.php
+++ b/src/Extension/ServiceContainer/Extension.php
@@ -28,7 +28,7 @@ class Extension implements ExtensionInterface
      *
      * Create definition object to handle in the context?
      */
-    public function process(ContainerBuilder $container)
+    public function process(ContainerBuilder $container): void
     {
         return;
     }


### PR DESCRIPTION
Symfony 8 added return types to all interfaces and classes. This leaks through the Behat API in places where Behat used classes from Symfony, for example the Event Dispatcher implementation or the `\Behat\Testwork\ServiceContainer\Extension` interface which extends `\Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface`.

The Behat maintainers work on creating a new Behat release supporting Symfony 8, but it will also affect extensions like this one (https://github.com/Behat/Behat/pull/1687).
